### PR TITLE
Fix: MultiSelectFieldContainer-Style: added 'max-width:100%;'

### DIFF
--- a/src/MultiSelectField/MultiSelectField.scss
+++ b/src/MultiSelectField/MultiSelectField.scss
@@ -1,6 +1,7 @@
 .mdl-multiselect {
   position: relative;
   width: 300px;
+  max-width: 100%;
   padding: 20px 0;
 
   .mdl-multiselect__container {


### PR DESCRIPTION
Fix: prevent MultiSelectFieldContainer from becoming bigger than parent element